### PR TITLE
Redirect CLI-related URLs to dedicated GitHub repo

### DIFF
--- a/cli/index.html
+++ b/cli/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE HTML>                                                                
+<html lang="en">                                                                
+    <head>                                                                      
+        <meta charset="utf-8">
+        <meta http-equiv="refresh" content="0;url=https://github.com/exoscale/cli" />      
+        <link rel="canonical" href="https://github.com/exoscale/cli" />                    
+    </head>
+    <body>The page been moved to <a href="https://github.com/exoscale/cli">https://github.com/exoscale/cli</a></body>
+</html>


### PR DESCRIPTION
This change redirects the `exoscale.github.io/cli/` URL to the
dedicated CLI GitHub repository.